### PR TITLE
Go implementation of alphanumeric-string-sort

### DIFF
--- a/problems/alphanumeric-string-sort/alphanumeric-string-sort.go
+++ b/problems/alphanumeric-string-sort/alphanumeric-string-sort.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+)
+
+var bytesInOrder map[byte]uint8
+
+func init() {
+	bytesInOrder = make(map[byte]uint8)
+	orderSlice := []byte("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0246813579")
+	for idx, val := range orderSlice {
+		bytesInOrder[val] = uint8(idx)
+	}
+}
+
+// AlphanumericString is a type for alphanumeric string
+type AlphanumericString []byte
+
+func (a AlphanumericString) Len() int           { return len(a) }
+func (a AlphanumericString) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a AlphanumericString) Less(i, j int) bool { return bytesInOrder[a[i]] < bytesInOrder[a[j]] }
+
+func alphanumSort(str string) string {
+	alphanumStr := AlphanumericString([]byte(str))
+	sort.Sort(alphanumStr)
+	return string(alphanumStr)
+}
+
+func main() {
+	fmt.Println(alphanumSort("Sorting0123456789"))           // ginortS0246813579
+	fmt.Println(alphanumSort("foobar1237348421"))            // abfoor2244811337
+	fmt.Println(alphanumSort("789765445whjdbjwhwfbs977865")) // bbdfhhjjswww446688555777799
+}

--- a/problems/alphanumeric-string-sort/alphanumeric-string-sort_test.go
+++ b/problems/alphanumeric-string-sort/alphanumeric-string-sort_test.go
@@ -1,0 +1,37 @@
+package main
+
+import "testing"
+
+func Test_alphanumSort(t *testing.T) {
+	type args struct {
+		str string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "General Scenario : Upper,Lower,Odd and Even",
+			args: args{"Sorting0123456789"},
+			want: "ginortS0246813579",
+		},
+		{
+			name: "No upper case",
+			args: args{"foobar1237348421"},
+			want: "abfoor2244811337",
+		},
+		{
+			name: "Only numbers",
+			args: args{"90856123456789"},
+			want: "02466881355799",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := alphanumSort(tt.args.str); got != tt.want {
+				t.Errorf("alphanumSort() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Implemeted type that implements sort.Interface for alphanumeric-string
Added test cases

How to test ?
```
 go test alphanumeric-string-sort_test.go alphanumeric-string-sort.go
```